### PR TITLE
fix: permalink parsing on timeline

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -19,7 +19,7 @@ function onMutation (mutations) {
     } else {
       const selectedTweet = e.target.closest('article')
       tweetUrl = selectedTweet.querySelector(
-        '[data-testid="User-Names"] [role="link"][dir="auto"]'
+        '[data-testid="User-Names"] [role="link"][href*="status"]'
       )?.href
     }
 


### PR DESCRIPTION
The previous implementation was using DIR attr as a selector, this can change based on region as it states the direction of the language (ltr or rtl, etc). We are now checking the link's href for instance of "status" this is more future proof and will work no matter the user's region or selected language.