### PR TITLE
Work with x.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Basic functionality can be achieved in a bookmarklet
 
 ```js
 javascript:(function(){
-  const url = document.location.href.match(/https:\/\/twitter.com\/(\w){1,15}\/status\/(\d)*/)[0];
+  const url = document.location.href.match(/https:\/\/x.com\/(\w){1,15}\/status\/(\d)*/)[0];
   if (url) window.open(`https://webrecorder.github.io/save-tweet-now/#url=${url}&autoupload=1`);
 })();
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Features
 
-Pin Tweet to IPFS is a [web extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions) targetting less-technical users who wish to archive Tweets in a verifiable way. It uses [IPFS](https://ipfs.tech/), [WebRecorder](https://webrecorder.net/), and [web3.storage](https://web3.storage/) to achieve this.
+Pin Tweet to IPFS is a [web extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions) targetting less-technical users who wish to archive Tweets (or "Xeets") in a verifiable way. It uses [IPFS](https://ipfs.tech/), [WebRecorder](https://webrecorder.net/), and [web3.storage](https://web3.storage/) to achieve this.
 
 ## How does it work?
 

--- a/esbuild.js
+++ b/esbuild.js
@@ -7,8 +7,8 @@ import cpy from "cpy";
 import { deleteSync } from "del";
 import esbuild from "esbuild";
 
-import pkg from "./package.json" assert { type: "json" };
-import manifest from "./src/manifest.json" assert { type: "json" };
+import pkg from "./package.json" with { type: "json" };
+import manifest from "./src/manifest.json" with { type: "json" };
 
 // delete old contents of build/ if exists
 deleteSync(["build/**"]);

--- a/src/Popup/index.jsx
+++ b/src/Popup/index.jsx
@@ -12,7 +12,7 @@ function main() {
 
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
     const currentTab = tabs[0] // there will be only one in this array
-      const tweetUrlMatch = currentTab.url.match(/https:\/\/twitter.com\/(\w){1,15}\/status\/(\d)*/)
+      const tweetUrlMatch = currentTab.url.match(/https:\/\/(twitter|x).com\/(\w){1,15}\/status\/(\d)*/)
     if (tweetUrlMatch) {
       const url = tweetUrlMatch[0]
       root.render(<Popup />)

--- a/src/background.js
+++ b/src/background.js
@@ -51,7 +51,7 @@ function init () {
     title: 'Pin Tweet to IPFS',
     contexts: ['link'],
     id: `pin-tweet-to-ipfs-${new Date().toISOString()}`, // unique id to avoid errors
-    targetUrlPatterns: ['https://twitter.com/*/status/*']
+    targetUrlPatterns: ['https://x.com/*/status/*']
   })
 
   chrome.contextMenus.onClicked.addListener((info) => archiveTweet(info.linkUrl))

--- a/src/content.js
+++ b/src/content.js
@@ -70,7 +70,7 @@ function onMutation (mutations) {
           .filter(
             (node) =>
               node.ariaLabel &&
-              node.ariaLabel.includes('eplies') &&
+              node.ariaLabel.includes('view') &&
               node.id &&
               !found.includes(node)
           )
@@ -80,7 +80,7 @@ function onMutation (mutations) {
           .apply(node.querySelectorAll('[aria-label]'))
           .filter(
             (node) =>
-              node.ariaLabel.includes('eplies') &&
+              node.ariaLabel.includes('view') &&
               node.id &&
               !found.includes(node)
           )

--- a/src/content.js
+++ b/src/content.js
@@ -67,7 +67,7 @@ function onMutation (mutations) {
           .apply(node.querySelectorAll("[role='group']"))
           .filter(
             (node) =>
-              !node.hasAttribute('aria-label') &&
+              node.ariaLabel.includes('eplies') &&
               node.id &&
               !found.includes(node)
           )

--- a/src/content.js
+++ b/src/content.js
@@ -26,7 +26,7 @@ function onMutation (mutations) {
     chrome.runtime.sendMessage({ url: tweetUrl })
   }
 
-  const createButton = () => {
+  const createButton = (small = false) => {
     // Icon svg
     const parser = new DOMParser()
     const logo = parser.parseFromString(iconLogo, 'image/svg+xml')
@@ -41,7 +41,8 @@ function onMutation (mutations) {
 
     const pinTweetButton = document.createElement('button')
     pinTweetButton.appendChild(pinTweetButton.ownerDocument.importNode(logo.documentElement, true))
-    pinTweetButton.appendChild(label)
+    if (!small)
+      pinTweetButton.appendChild(label)
     pinTweetButton.style.display = 'flex'
     pinTweetButton.style.backgroundColor = 'rgb(104 131 149)'
     pinTweetButton.style.color = '#fff'
@@ -51,7 +52,7 @@ function onMutation (mutations) {
     pinTweetButton.style.letterSpacing = '0.5px'
     pinTweetButton.style.padding = '5px 10px'
     pinTweetButton.style.cursor = 'pointer'
-    pinTweetButton.style.minWidth = '165px'
+    pinTweetButton.style.minWidth = small ? '' : '165px'
     pinTweetButton.addEventListener('click', (e) => getTweetUrl(e))
     pinTweetButton.id = `pin-tweet-${new Date().toISOString()}`
     return pinTweetButton
@@ -67,6 +68,7 @@ function onMutation (mutations) {
           .apply(node.querySelectorAll("[role='group']"))
           .filter(
             (node) =>
+              node.ariaLabel &&
               node.ariaLabel.includes('eplies') &&
               node.id &&
               !found.includes(node)
@@ -88,6 +90,6 @@ function onMutation (mutations) {
 
   found.forEach((n) => {
     if (n.querySelector("[id^='pin-tweet']")) return // return early if there is already a button appended
-    n.appendChild(createButton())
+    n.appendChild(createButton(n.offsetWidth < 165 * 2))
   })
 }

--- a/src/content.js
+++ b/src/content.js
@@ -55,6 +55,7 @@ function onMutation (mutations) {
     pinTweetButton.style.minWidth = small ? '' : '165px'
     pinTweetButton.addEventListener('click', (e) => getTweetUrl(e))
     pinTweetButton.id = `pin-tweet-${new Date().toISOString()}`
+    pinTweetButton.title = 'Pin Tweet to IPFS'
     return pinTweetButton
   }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,7 +17,8 @@
   "content_scripts": [
     {
       "matches": [
-        "https://*.twitter.com/*",
+        "https://*.x.com/*",
+        "https://x.com/*",
         "https://webrecorder.github.io/save-tweet-now/"
       ],
       "js": ["content.js"]


### PR DESCRIPTION
# Description
It doesn't work with x.com! Well it does now, if https://github.com/webrecorder/save-tweet-now/issues/8 gets fixed. We are visiting the right URL, it's all the backend's fault.

Closes: #269

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
  * My dog ate my GPG key.
- [ ] ~~If files added, I have modified [bundle.sh](https://github.com/meandavejustice/pin-tweet-to-ipfs/blob/main/bundle.sh) and [esbuild.js](https://github.com/meandavejustice/pin-tweet-to-ipfs/blob/main/esbuild.js) to ensure the new files are included in the package~~
- [ ] ~~I have added necessary documentation (if appropriate).~~

## Screenshots (Optional)

Concrete proof of it working. Somewhat.
![image](https://github.com/user-attachments/assets/ef16bedd-2eec-4cfb-aa6f-35e28ecc4d42)
![image](https://github.com/user-attachments/assets/f49e27c1-a750-49db-aa4a-a50e433611f5)

## Other information (Optional)

Any other information that is important to this pull request.